### PR TITLE
add optional email send object with to, cc, bcc properties

### DIFF
--- a/server/libs/mailer.js
+++ b/server/libs/mailer.js
@@ -11,9 +11,26 @@ module.exports = {
 		logger.info(`Sending email to ${recipients} with subject ${subject}...`);
 		logger.debug("Deprecated! libs/mailer is deprecated. Use Service.get('mailer') instead!");
 
+		// recipients can be a comma separated string or array which will be sent by the 'to' field
+		// recipients can also be an object with to, cc, bcc properties etc. See: 'Common fields' https://community.nodemailer.com/
+		let emailRecipients = {}
+		if (recipients instanceof Object) {
+			if(recipients instanceof Array) {
+				emailRecipients.to = recipients
+			}
+			else {
+				emailRecipients = recipients
+			}
+		}
+		else {
+			emailRecipients.to = recipients
+		} 
+
 		let mailOptions = {
 			from: config.mailer.from,
-			to: recipients,
+			to: emailRecipients.to,
+			cc: emailRecipients.cc,
+			bcc: emailRecipients.bcc,
 			subject: subject,
 			html: body
 		};

--- a/server/services/mailer.js
+++ b/server/services/mailer.js
@@ -23,9 +23,26 @@ module.exports = {
 
 				logger.info(`Sending email to ${recipients} with subject ${subject}...`);
 
+				// recipients can be a comma separated string or array which will be sent by the 'to' field
+				// recipients can also be an object with to, cc, bcc properties etc. See: 'Common fields' https://community.nodemailer.com/
+				let emailRecipients = {}
+				if (recipients instanceof Object) {
+					if(recipients instanceof Array) {
+						emailRecipients.to = recipients
+					}
+					else {
+						emailRecipients = recipients
+					}
+				}
+				else {
+					emailRecipients.to = recipients
+				} 
+
 				let mailOptions = {
 					from: config.mailer.from,
-					to: recipients,
+					to: emailRecipients.to,
+					cc: emailRecipients.cc,
+					bcc: emailRecipients.bcc,
 					subject: subject,
 					html: body
 				};


### PR DESCRIPTION
email recipients can be a comma separated string or array which will be sent by the 'to' field (current feature)

email recipients can optionally be an object with to, cc, bcc properties etc. (optional feature)

See: 'Common fields' https://community.nodemailer.com/