### PR TITLE
master <- fixed limit/offset type bug

### DIFF
--- a/server/core/context.js
+++ b/server/core/context.js
@@ -572,11 +572,15 @@ class Context {
 	 */
 	queryPageSort(query) {
 		if (this.params) {
-			if (this.params.limit)
-				query.limit(this.params.limit);
+			if (this.params.limit) {
+				let limit = parseInt(this.params.limit);
+				query.limit(limit);
+			}
 
-			if (this.params.offset)
-				query.skip(this.params.offset);
+			if (this.params.offset) {
+				let offset = parseInt(this.params.offset);
+				query.skip(offset);
+			}
 
 			if (this.params.sort)
 				query.sort(this.params.sort.replace(/,/, " "));


### PR DESCRIPTION
since the limit/offset param is number but represented as string, mongod complains that it can't use it.
a simple solution for my use case, since I'm using pagination in the API